### PR TITLE
DRGN-11180: Deselect nRF5 Clock controller if BT_LL_NRFXLIB enabled

### DIFF
--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -1,7 +1,7 @@
 zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_BEETLE              beetle_clock_control.c)
 zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_MCUX_CCM            clock_control_mcux_ccm.c)
 zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_MCUX_SIM            clock_control_mcux_sim.c)
-zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF5                nrf5_power_clock.c)
+zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_NRF5_DEFAULT        nrf5_power_clock.c)
 zephyr_sources_ifdef(CONFIG_CLOCK_CONTROL_QUARK_SE            quark_se_clock_control.c)
 
 if(CONFIG_CLOCK_CONTROL_STM32_CUBE)

--- a/drivers/clock_control/Kconfig.nrf5
+++ b/drivers/clock_control/Kconfig.nrf5
@@ -5,11 +5,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig CLOCK_CONTROL_NRF5
-	bool "NRF5 Clock controller support"
-	depends on SOC_COMPATIBLE_NRF
+        bool "NRF5 Clock controller support"
+        depends on SOC_COMPATIBLE_NRF
+        select CLOCK_CONTROL_NRF5_IMPL
+        help
+          Enable support for the Nordic Semiconductor nRF5x series SoC clock
+          driver.
+
+choice CLOCK_CONTROL_NRF5_IMPL
+        bool
+        prompt "nRF5 Clock controller implementation"
+        default CLOCK_CONTROL_NRF5_DEFAULT
+
+config CLOCK_CONTROL_NRF5_DEFAULT
+        bool "Default NRF5 Clock controller support"
+        depends on BT_LL_SW
 	help
-	  Enable support for the Nordic Semiconductor nRF5x series SoC clock
-	  driver.
+          Enable default implementation of the Nordic Semiconductor nRF5x
+          series SoC clock driver.
+
+endchoice
 
 if CLOCK_CONTROL_NRF5
 
@@ -28,7 +43,7 @@ config CLOCK_CONTROL_NRF5_K32SRC_DRV_NAME
 	string "NRF5 32KHz clock device name"
 	default "clk_k32src"
 
-choice
+choice CLOCK_CONTROL_NR5_SOURCE
 	prompt "32KHz clock source"
 	default CLOCK_CONTROL_NRF5_K32SRC_XTAL
 
@@ -49,7 +64,7 @@ config CLOCK_CONTROL_NRF5_K32SRC_BLOCKING
 	  initially start running and automatically switch to crystal when
 	  ready.
 
-choice
+choice CLOCK_CONTROL_NR5_ACCURACY
 	prompt "32KHz clock accuracy"
 	default CLOCK_CONTROL_NRF5_K32SRC_500PPM if CLOCK_CONTROL_NRF5_K32SRC_RC
 	default CLOCK_CONTROL_NRF5_K32SRC_20PPM
@@ -81,3 +96,4 @@ config CLOCK_CONTROL_NRF5_K32SRC_20PPM
 endchoice
 
 endif # CLOCK_CONTROL_NRF5
+

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -152,7 +152,6 @@ config ALTERA_AVALON_TIMER
 config NRF_RTC_TIMER
 	bool "nRF Real Time Counter (NRF_RTC1) Timer"
 	default y
-	depends on CLOCK_CONTROL_NRF5
 	select TICKLESS_CAPABLE
 	help
 	  This module implements a kernel device driver for the nRF Real Time

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.series
@@ -12,8 +12,8 @@ config  SOC_SERIES_NRF52X
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_NRF
 	select NRF_RTC_TIMER
-	select CLOCK_CONTROL
-	select CLOCK_CONTROL_NRF5
+        select CLOCK_CONTROL
+        select CLOCK_CONTROL_NRF5
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select SYS_POWER_STATE_CPU_LPS_SUPPORTED
 	select SYS_POWER_STATE_CPU_LPS_1_SUPPORTED
@@ -24,4 +24,4 @@ config  SOC_SERIES_NRF52X
 	select HAS_NRFX
 	select HAS_SEGGER_RTT
 	help
-	 Enable support for NRF52 MCU series
+         Enable support for NRF52 MCU series


### PR DESCRIPTION
The default nRF5 Clock controller can't be used when ble_controller is
nabled (BT_LL_NRFXLIB). The choice is added to solve this.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>