### PR TITLE
bluetooth: host: Use default HCI stack size if no BT_LL_SW

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -48,16 +48,18 @@ config BT_RX_BUF_LEN
 	  (4 bytes) and the ACL header (also 4 bytes) which yields 73 bytes.
 
 config BT_HCI_TX_STACK_SIZE
+	# NOTE: By _not_ having a prompt here, Kconfig will fall back on
+	# the default value if none of the other values are set.
 	int
 	default 512 if BT_H4
 	default 512 if BT_H5
 	default 416 if BT_SPI
-	default 940 if BT_CTLR && NO_OPTIMIZATIONS
-	default 640 if BT_CTLR
+	default 940 if BT_CTLR && (BT_LL_SW || BT_LL_SW_SPLIT) && NO_OPTIMIZATIONS
+	default 640 if BT_CTLR && (BT_LL_SW || BT_LL_SW_SPLIT)
 	default 512 if BT_USERCHAN
 	# Even if no driver is selected the following default is still
 	# needed e.g. for unit tests.
-	default 512
+	default 1024
 	help
 	  Stack size needed for executing bt_send with specified driver
 


### PR DESCRIPTION
Increase the default BT_HCI_TX_STACK_SIZE and make it user
configurable. If there is a BT_CTRL controller out-of-tree
with different requirements to the stack size, the default
is at least sufficiently high and it's user configurable.

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>